### PR TITLE
Include only glib.h

### DIFF
--- a/charset/fribidi-char-sets.c
+++ b/charset/fribidi-char-sets.c
@@ -114,7 +114,7 @@ static FriBidiCharSetHandler char_sets[FRIBIDI_CHAR_SETS_NUM + 1] = {
 };
 
 #if FRIBIDI_USE_GLIB+0
-# include <glib/gstrfuncs.h>
+# include <glib.h>
 # define fribidi_strcasecmp g_ascii_strcasecmp
 #else /* !FRIBIDI_USE_GLIB */
 static char


### PR DESCRIPTION
Fixes error: #error "Only glib.h can be included directly."
with certain glib versions.

I can't reproduce this on my system (glib 2.38.1), but a user reported it happens with a very recent glib. It's the correct way to use glib anyway.